### PR TITLE
Corrected link for Start-TypedDemo.md in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ install-module psteachingtools
 ```
 
 The module also includes a function for simulating an interactive PowerShell console session. You can type your commands in a file and have the function "play back" the commands
-just as if you were typing the commands. The function will pause after every | character. Pressing Enter will advance the demo. Read help for [Start-TypedDemo](./docs/Start-TypedDemo.md). A [sample file](./assets/sampledemo.txt) is included in this module.
+just as if you were typing the commands. The function will pause after every | character. Pressing Enter will advance the demo. Read help for [Start-TypedDemo](./Docs/Start-TypedDemo.md). A [sample file](./assets/sampledemo.txt) is included in this module.
 
 The module should work in both Windows PowerShell and PowerShell Core. Please post an issue with any feedback, suggestions or problems.
 


### PR DESCRIPTION
The link to Start-TypedDemo.md is under the "Docs" directory, with a capital "D". I also was not aware the path was case-sensitive on Github.

It's a small change; just thought I'd help out. Feel free to ignore. Thanks for all you do!